### PR TITLE
Update extensions

### DIFF
--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -24,8 +24,8 @@
   },
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
-    "vscode-dart": "https://github.com/Dart-Code/Dart-Code/releases/download/v3.60.0/dart-code-3.60.0.vsix",
-    "vscode-flutter": "https://github.com/Dart-Code/Flutter/releases/download/v3.60.0/flutter-3.60.0.vsix"
+    "Dart-Code.dart-code": "https://github.com/Dart-Code/Dart-Code/releases/download/v3.63.20230504/dart-code-3.63.20230504.vsix",
+    "Dart-Code.flutter": "https://github.com/Dart-Code/Flutter/releases/download/v3.62.0/flutter-3.62.0.vsix"
   },
   "scripts": {
     "prepare": "theia build --mode development",


### PR DESCRIPTION
This updates the extensions to the latest versions (a pre-release of the Dart one with a fix for https://github.com/Dart-Code/Dart-Code/issues/4519, and the latest stable for Flutter).

It also uses their published identifiers, since without them it seemed to pull a duplicate of the Dart extension (the Flutter extension says it depends on "Dart-Code.dart-code" which caused it to fetch that).

With this version, I can use the **Attach to Flutter Process** command and paste in a VM Service URI and do some basic debugging. I haven't thoroughly tested what works/doesn't though.

Some other observations though:

- it doesn't seem like any language functionality is working (no hovers, completion).. I haven't investigated why - it could be a mismatch between the APIs the VS Code LSP client thinks it has, and what Theia has. If you get to the point where that would be useful to fix, let me know and I can invesigate.
- We're showing CodeLens links for Run/Debug in this editor, and they work (I guess because the extension host happens to be on your local machine). We might want to investigate a way to hide stuff like that if we do this, because it would be rather odd to be launching additional copies of your app from embedded inside DevTools that is connected to another :-)

Let me know if you hit any other issues!